### PR TITLE
Revamp reservation form: 3-step flow, in-card extra hours, layout selector

### DIFF
--- a/docs/plans/reservation-form-changes-plan.md
+++ b/docs/plans/reservation-form-changes-plan.md
@@ -1,0 +1,83 @@
+# Reservation Form — Implementation Plan
+
+Implementation plan for the changes in [`reservation-form-requested-changes.md`](../reservation-form-requested-changes.md).
+
+## Confirmed decisions (from clarifying questions)
+
+| Topic | Decision |
+|---|---|
+| Header | Main title **"Get a tailored quote in 3 steps"** + a **persistent step indicator** (`① Basic details · ② Extras · ③ About you`) shown on every step, current step highlighted. Each step also shows its full-phrase heading. |
+| Durations | Three options become **8h / 4h / 2h**. Weekend/Evening base = **€270** for 2 hrs. |
+| Extra hours | **One unified extra-hours picker on step 1** (catering-style stepper), **€60 / extra hour**, capped so `duration + extra ≤ 12h`. The separate step-2 "Extra Time" upsell from the doc is **not** built. |
+| Layout | Section heading → **"What layout do you require?"**; options **Boardroom / U-shape / Classroom / Circle / Theatre** (drop "Intimate"); the venue card is kept as a **display-only** image (no "Choose" button). |
+| Catering | Replace the paragraph copy with **"If you want to keep your energy high choose your preferred catering options."** (drops the catering-options link). |
+| Final step | Heading → **"Tell us who you are"**; remove the "reply within 10 minutes" sentence; remove the duplicate **nav-row** submit button (keep Back); keep the in-form button, renamed **"Request Quote"**. All other submit buttons (mobile bar/drawer) relabeled to "Request Quote" too. |
+
+### Step heading flow
+
+- Step 1: **Give us the basic details**
+- Step 2: **Choose your extras**
+- Step 3: **Tell us who you are**
+
+## Zoho integration
+
+The widget's **displayed** total comes from `src/data/index.js` prices; the **Zoho estimate** amounts come from each Zoho item's configured price. Both new items already exist in org `20113447459` at the right price, so **no Zoho-side changes are needed** — only the correct item IDs in the data file:
+
+1. **Weekend/Evening = €270 / 2 hrs** — package 3 `zoho_id` set to `936322000000090488`.
+2. **Extra hours = €60 / hr** — `extraHourZohoId` set to `936322000000090454` (sent with `quantity = extraHours × days`).
+3. **Layout choice** is sent to the Zoho estimate `notes` (`Layout: {tableSetup}`) AND to Google Sheets as a new **trailing** column (appended after `adsID`, so no existing columns shift). ⚠️ The Google Sheet must have a "Layout" header column added at the far right to receive it.
+4. **Event end time** includes extra hours (departure = last day's package hours + extra hours). **Extra hours** also appear in the Sheets "Duration" field (`8 (+2h extra)`) and the Zoho `custom_subject`.
+
+## File-by-file changes
+
+### `src/data/index.js`
+- Package 3: `duration_hours: 1 → 2`; `short_description` `"Hourly Rate"/"Uurtarief"` → `"Weekend / Evening"/"Weekend / Avond"`.
+- `mockVenuePackages` ids 3 & 6: `price 120 → 270`.
+- Add exports: `EXTRA_HOUR_RATE = 60`, `MAX_TOTAL_HOURS = 12`, `extraHourZohoId` (placeholder).
+
+### `src/components/ui/step-indicator.jsx` (new)
+Renders the main title + the 3-step progress indicator with the active step highlighted.
+
+### `src/components/ui/quantity-stepper.jsx` (new)
+Extracted, **enabled** −/value/+ stepper (the catering card's stepper is currently hard-coded `disabled`). Used for the extra-hours picker. Props: `value`, `onChange`, `min`, `max`, optional label.
+
+### `src/components/booking-widget.jsx`
+- New `extraHours` state (default `0`); clamp/reset when the selected duration changes.
+- Render `<StepIndicator currentStep>` above the step switch (steps 1–3); remove the old step-1 intro `<h2>/<p>`.
+- Pricing `useEffect`: add `extraHours * EXTRA_HOUR_RATE` (per day, mirroring facilities/catering).
+- Pass `extraHours` / `setExtraHours` to `Step1` and `Overview`.
+- Zoho `line_items`: push extra-hours item (`quantity = extraHours × days`); add layout to `custom_subject`/`notes`.
+- Step-3 desktop nav row: **remove the submit button, keep Back**.
+
+### `src/components/booking-widget-step-1.jsx`
+- Duration cards show **label + duration** (`"Full day" / "8 hours"`); the Weekend/Evening card shows `"2 hrs @ €270"`.
+- Add the **extra-hours stepper** below the duration cards (shown once a duration is picked; `max = 12 − duration`; live €60×n cost).
+- Add the step heading **"Give us the basic details"**.
+- Venue section: heading → **"What layout do you require?"**; venue card **display-only**; `Select` options → Boardroom / U-shape / Classroom / Circle / Theatre.
+
+### `src/components/ui/card-option.jsx`
+Add an optional subtitle/meta line (duration / price). Keep `aria-label` = the label.
+
+### `src/components/ui/venue-card-option.jsx`
+Add a `displayOnly` prop that hides the "Choose" button (card stays present; selection still wired).
+
+### `src/components/booking-widget-step-2.jsx`
+- Heading → **"Choose your extras"**.
+- Replace the catering paragraph with the new sentence.
+
+### `src/components/booking-widget-step-3.jsx`
+- Heading → **"Tell us who you are"**.
+- Remove the "reply within 10 minutes" sentence.
+- Button label/aria → **"Request Quote"**.
+
+### `src/components/booking-widget-overview.jsx`
+- Add an "Extra hours × n" line + cost when `extraHours > 0`.
+- Relabel the mobile-bar/drawer submit buttons to **"Request Quote"**.
+
+### Tests
+Update assertions affected by copy/label changes (`booking-widget`, `step-1`, `step-2`, `step-3`, `overview` test files): step headings, duration aria-labels (`8 Hours`→`Full day`, `4 Hours`→`Half day`), and submit-button labels (`Request Proposal*`→`Request Quote*`). Run `npm run test` + `npm run lint`.
+
+## Out of scope / left as-is
+- `thank-you.jsx` "within 10 minutes" copy (unchanged unless requested).
+- Catering card quantity stepper stays disabled (separate pre-existing behavior).
+- New UI copy is English-only (matches the existing hardcoded-heading convention); bilingual data fields get both `en`/`nl`.

--- a/docs/reservation-form-requested-changes.md
+++ b/docs/reservation-form-requested-changes.md
@@ -1,0 +1,92 @@
+# Reservation Form Requested Changes
+
+These are the requested UX and copy changes for the public reservation/request form.
+
+## Step Structure And Messaging
+
+Update the form heading flow to:
+
+1. Give us the basic details
+2. Choose your extras
+3. Tell us who you are
+
+Replace the current intro copy with:
+
+> Get a tailored quote in 3 steps
+
+This should be the main title, with the three steps shown below it.
+
+## Duration Options
+
+Update the duration cards to better match the pricing page terminology.
+
+### Full Day
+
+- Label: `Full day`
+- Duration: `8 hours`
+
+### Half Day
+
+- Label: `Half day`
+- Duration: `4 hours`
+
+### Weekend / Evening Booking
+
+- Label: `Weekend / Evening`
+- Default: `2 hrs @ €270`
+- Allow adding extra hours:
+  - `+1 hour`
+  - `+2 hours`
+  - etc.
+
+## Layout Options
+
+Question to confirm during implementation:
+
+- Should the venue selector be removed since there is only one venue?
+
+Current direction:
+
+- The image can remain.
+- Replace `Venue Preference` with `What layout do you require?`
+
+Layout options:
+
+- Boardroom
+- U-shape
+- Classroom
+- Circle
+- Theatre
+
+## Catering Copy
+
+Replace the catering section copy with:
+
+> If you want to keep your energy high choose your preferred catering options.
+
+## Extra Time Upsell
+
+Add a new upsell module:
+
+### Extra Time
+
+- Price: `€60/hr`
+- Hour selector:
+  - `1`
+  - `2`
+  - `3`
+
+## Final Step Copy And CTA
+
+Update the current `Almost there` final step heading to:
+
+> Tell us who you are
+
+Remove the sentence that refers to a reply within 10 minutes.
+
+There are currently two `Request proposal` buttons on the final step:
+
+- Remove one of them.
+- Rename the remaining button to:
+
+> Request Quote

--- a/src/components/booking-widget-overview.jsx
+++ b/src/components/booking-widget-overview.jsx
@@ -6,7 +6,7 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { useMediaQuery } from '@/hooks/use-media-query';
-import { check } from 'prettier';
+import { EXTRA_HOUR_RATE } from '@/data';
 
 const Overview = ({ 
   language,
@@ -21,9 +21,10 @@ const Overview = ({
   checkStep1Errors,
   isStep3Valid,
   checkStep3Errors,
-  facilitiesSelected, 
-  cateringSelected, 
+  facilitiesSelected,
+  cateringSelected,
   selectedEventPackages,
+  extraHours = 0,
   totalExclVat,
   handleSubmit,
   submitting
@@ -116,8 +117,18 @@ const Overview = ({
             <span className="text-sm">
               {`${item.price * item.quantity}€`}
             </span>
-          </div>  
+          </div>
         ))}
+        {extraHours > 0 && (
+          <div className="flex items-center justify-between space-x-2">
+            <span className="text-sm">
+              {`Extra hours x ${extraHours}`}<span className="text-muted-foreground">{selectedEventPackages.length > 1 ? ` per day` : ''}</span>
+            </span>
+            <span className="text-sm">
+              {`${extraHours * EXTRA_HOUR_RATE}€`}
+            </span>
+          </div>
+        )}
       {currentStep > 1 && venue && guests > 0 && <hr />}
         <div className="flex items-center justify-between space-x-2">
           <span className="text-md font-medium">
@@ -178,14 +189,14 @@ const Overview = ({
                   <Button variant="outline" onClick={() => setCurrentStep(2)}>
                     <ArrowLeftIcon className="mr-2 h-5 w-5 text-muted-foreground" />
                   </Button>
-                  <Button 
-                    aria-label="Request Proposal Overview"
+                  <Button
+                    aria-label="Request Quote Overview"
                     disabled={!isStep3Valid()} onClick={() => {
                       if (checkStep3Errors() && isStep3Valid()) {
                         handleSubmit()
                       }
                     }}>
-                    {submitting ? 
+                    {submitting ?
                     (
                       <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
@@ -193,7 +204,7 @@ const Overview = ({
                       </svg>
                     )
                   : (
-                    <span className="flex space-x-2">Request <ArrowRightIcon className="ml-2 h-5 w-5 text-white" />
+                    <span className="flex space-x-2">Request Quote <ArrowRightIcon className="ml-2 h-5 w-5 text-white" />
                     </span>
                   )}
                   </Button>
@@ -237,16 +248,16 @@ const Overview = ({
                   }}>
                     <ArrowLeftIcon className="mr-2 h-5 w-5 text-muted-foreground" />
                   </Button>
-                  <Button 
-                    aria-label="Request Proposal Overview Drawer"
+                  <Button
+                    aria-label="Request Quote Overview Drawer"
                     className="w-full min-w-fit"
-                    disabled={!isStep3Valid()} 
+                    disabled={!isStep3Valid()}
                     onClick={() => {
                       if (checkStep3Errors() && isStep3Valid()) {
                         handleSubmit()
                       }
                     }}>
-                    {submitting ? 
+                    {submitting ?
                     (
                       <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
@@ -254,7 +265,7 @@ const Overview = ({
                       </svg>
                     )
                   : (
-                    <span className="flex space-x-2">Request Proposal <ArrowRightIcon className="ml-2 h-5 w-5 text-white" />
+                    <span className="flex space-x-2">Request Quote <ArrowRightIcon className="ml-2 h-5 w-5 text-white" />
                     </span>
                   )}
                   </Button>

--- a/src/components/booking-widget-overview.test.jsx
+++ b/src/components/booking-widget-overview.test.jsx
@@ -63,7 +63,7 @@ describe('Overview', () => {
         checkStep3Errors={vi.fn().mockReturnValue(true)}
       />
     );
-    fireEvent.click(getByLabelText('Request Proposal Overview'));
+    fireEvent.click(getByLabelText('Request Quote Overview'));
     expect(mockProps.handleSubmit).toHaveBeenCalled();
   });
 

--- a/src/components/booking-widget-step-1.jsx
+++ b/src/components/booking-widget-step-1.jsx
@@ -1,48 +1,63 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { CardOption } from "@/components/ui/card-option"
-import { VenueCardOption } from "@/components/ui/venue-card-option"
+import { LayoutCardOption } from "@/components/ui/layout-card-option"
 import { DatePicker } from "@/components/ui/date-picker";
 import {
-  Select,
-  SelectTrigger,
-  SelectContent,
-  SelectItem,
-  SelectValue,
-} from "@/components/ui/select";
-import { UserIcon, CalendarDaysIcon, ClockIcon } from "@/components/icons";
+  UserIcon,
+  UsersIcon,
+  RulerIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+  BoardroomGlyph,
+  UShapeGlyph,
+  ClassroomGlyph,
+  CircleGlyph,
+  TheatreGlyph,
+} from "@/components/icons";
+import { mockVenuePackages, EXTRA_HOUR_RATE, MAX_TOTAL_HOURS } from "@/data";
 
-const Step1 = ({ 
+const LAYOUTS = [
+  { value: "Boardroom", label: "Boardroom", Glyph: BoardroomGlyph },
+  { value: "U-shape", label: "U-shape", Glyph: UShapeGlyph },
+  { value: "Classroom", label: "Classroom", Glyph: ClassroomGlyph },
+  { value: "Circle", label: "Circle", Glyph: CircleGlyph },
+  { value: "Theatre", label: "Theatre", Glyph: TheatreGlyph },
+];
+
+const Step1 = ({
   language,
-  guests, 
-  setGuests, 
+  guests,
+  setGuests,
   guestsError,
   setGuestsError,
-  date, 
-  setDate, 
+  date,
+  setDate,
   dateError,
-  endDate, 
-  setEndDate, 
+  endDate,
+  setEndDate,
   endDateError,
-  time, 
-  setTime, 
+  time,
+  setTime,
   timeError,
-  endTime, 
-  setEndTime, 
-  isMultiDay, 
-  setMultiDay, 
-  tableSetup, 
-  setTableSetup, 
+  endTime,
+  setEndTime,
+  isMultiDay,
+  setMultiDay,
+  tableSetup,
+  setTableSetup,
   venue,
-  setVenue, 
+  setVenue,
   venueError,
   eventPackages,
   eventPackagesError,
   selectedEventPackages,
   setSelectedEventPackages,
-  venues 
+  extraHours = 0,
+  setExtraHours = () => {},
+  venues
 }) => {
 
   const handleSelectEventPackage = (index, id) => {
@@ -51,20 +66,52 @@ const Step1 = ({
     setSelectedEventPackages(newPackages);
   }
 
+  // Price of a package for the currently selected venue.
+  const getPackagePrice = (packageId) =>
+    mockVenuePackages.find(vp => vp.venue_id === venue && vp.package_id === packageId)?.price;
+
+  // Card title is the package label; subtitle shows the duration (and price for
+  // the increment-rate / Weekend-Evening package).
+  const packageTitle = (pkg) => pkg.short_description?.[language] || `${pkg.duration_hours} hours`;
+  const packageSubtitle = (pkg) => {
+    const price = getPackagePrice(pkg.id);
+    if (pkg.is_increment_rate && price) {
+      return `${pkg.duration_hours} hrs @ €${price}`;
+    }
+    return `${pkg.duration_hours} hour${pkg.duration_hours === 1 ? '' : 's'}`;
+  };
+
+  // Extra-hours cap: keep duration + extra hours within MAX_TOTAL_HOURS for every selected day.
+  const selectedDurations = selectedEventPackages
+    .map(id => eventPackages.find(pkg => pkg.id === id)?.duration_hours)
+    .filter((hours) => typeof hours === 'number');
+  const maxSelectedDuration = selectedDurations.length ? Math.max(...selectedDurations) : 0;
+  const maxExtraHours = Math.max(0, MAX_TOTAL_HOURS - maxSelectedDuration);
+  const hasDurationSelected = selectedEventPackages.some(Boolean);
+
+  // Clamp extra hours to the available headroom; reset to 0 when no duration is selected.
+  useEffect(() => {
+    const cap = hasDurationSelected ? maxExtraHours : 0;
+    if (extraHours > cap) {
+      setExtraHours(cap);
+    }
+  }, [hasDurationSelected, maxExtraHours, extraHours, setExtraHours]);
+
   return (
     <>
+      <h2 className="text-xl font-bold text-center mt-8">Give us the basic details</h2>
       <div className="space-y-4 mt-8 grid grid-rows-2 justify-center lg:max-w-[680px] mx-auto">
         <div className="grid md:grid-cols-2 space-y-4 md:space-y-0 md:space-x-4 ">
           <div className="lg:max-w-[330px] w-full">
             <Label htmlFor="guests">Number of guests</Label>
             <div className="relative mt-2">
-              <Input 
+              <Input
                 className={`pr-8 ${guestsError && "border-red-500"}`}
-                type="number" 
-                id="guests" 
-                placeholder="12" 
-                max="20" 
-                value={guests} 
+                type="number"
+                id="guests"
+                placeholder="12"
+                max="20"
+                value={guests}
                 onChange={(e) => {setGuests(e.target.value); setGuestsError(null)}}
               />
               <UserIcon className="absolute right-2 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />
@@ -74,8 +121,8 @@ const Step1 = ({
           <div className="lg:max-w-[330px] w-full">
             <Label htmlFor="date">When is it happening</Label>
             <div className="relative mt-2">
-              <DatePicker 
-                date={date} 
+              <DatePicker
+                date={date}
                 setDate={
                   (date) => {
                     setDate(date);
@@ -104,7 +151,7 @@ const Step1 = ({
           </div>
           <div className="flex items-center space-x-2">
             <Switch id="multi-day" checked={isMultiDay} onClick={(e) => {
-              setMultiDay(!isMultiDay); 
+              setMultiDay(!isMultiDay);
               if (date && !isMultiDay) {
                 setEndDate(new Date(new Date(date).getTime() + 24 * 60 * 60 * 1000));
                 if (time) {
@@ -126,9 +173,9 @@ const Step1 = ({
               <div className="lg:max-w-[330px] w-full">
                 <Label htmlFor="end-date">End date</Label>
                 <div className="relative mt-2">
-                  <DatePicker 
-                    date={endDate} 
-                    setDate={setEndDate} 
+                  <DatePicker
+                    date={endDate}
+                    setDate={setEndDate}
                     // disable days before the start date
                     disabled={(d) => new Date(d) < new Date(date)}
                     label={"Pick an end date"}
@@ -157,13 +204,18 @@ const Step1 = ({
               {eventPackages.map(pkg => (
                 <CardOption
                   key={pkg.id}
-                  title={`${pkg.duration_hours} Hours`}
+                  title={packageTitle(pkg)}
+                  subtitle={packageSubtitle(pkg)}
                   description={pkg.description[language]}
                   onClick={() => handleSelectEventPackage(index, pkg.id)}
                   id={pkg.id}
                   isSelected={selectedEventPackages[index] === pkg.id}
                   noneSelected={!selectedEventPackages[index]}
                   value={pkg.id}
+                  extraHours={extraHours}
+                  onExtraHoursChange={setExtraHours}
+                  maxExtraHours={maxExtraHours}
+                  extraHourRate={EXTRA_HOUR_RATE}
                 />
               ))}
             </div>
@@ -173,13 +225,18 @@ const Step1 = ({
             {eventPackages.map(pkg => (
               <CardOption
                 key={pkg.id}
-                title={`${pkg.duration_hours} Hours`}
+                title={packageTitle(pkg)}
+                subtitle={packageSubtitle(pkg)}
                 description={pkg.description[language]}
                 onClick={() => handleSelectEventPackage(0, pkg.id)}
                 id={pkg.id}
                 isSelected={selectedEventPackages.length > 0 && selectedEventPackages[0] === pkg.id}
                 noneSelected={selectedEventPackages.length === 0}
                 value={pkg.id}
+                extraHours={extraHours}
+                onExtraHoursChange={setExtraHours}
+                maxExtraHours={maxExtraHours}
+                extraHourRate={EXTRA_HOUR_RATE}
               />
             ))}
           </div>
@@ -187,38 +244,43 @@ const Step1 = ({
       { eventPackagesError && <p className="text-red-500 text-sm mt-1">{eventPackagesError}</p> }
       </div>
       </div>
-      <div className="mt-12 space-y-8 flex flex-col items-center lg:max-w-[680px] mx-auto">
+      <div className="mt-12 space-y-6 flex flex-col items-center lg:max-w-[680px] mx-auto">
         <h3 className="text-lg font-bold text-center">
-          Venue Preference
+          What layout do you require?
         </h3>
-        <div className="grid  gap-4 mt-4">
-          {venues.map(v => (
-            <VenueCardOption
-              key={v.id}
-              venue_name={v.name[language]}
-              venue_description={v.description[language]}
-              image_url={v.images[0]}
-              capacity={v.capacity}
-              area={v.area}
-              isSelected={v.id === venue}
-              onClick={() => setVenue(v.id)}
+        {venues.map(v => (
+          <div key={v.id} className="flex items-center gap-3 w-full rounded-lg bg-gray-50 border p-3">
+            <img
+              src={v.images[0]}
+              alt={v.name[language]}
+              loading="lazy"
+              className="h-14 w-20 rounded-md object-cover shrink-0"
+            />
+            <div className="min-w-0">
+              <p className="font-bold leading-tight">{v.name[language]}</p>
+              <div className="flex items-center gap-3 text-sm text-muted-foreground mt-0.5">
+                <span className="flex items-center gap-1">
+                  <UsersIcon className="h-4 w-4" /> up to {v.capacity}
+                </span>
+                <span className="flex items-center gap-1">
+                  <RulerIcon className="h-4 w-4" /> {v.area} m²
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 w-full">
+          {LAYOUTS.map(({ value, label, Glyph }) => (
+            <LayoutCardOption
+              key={value}
+              label={label}
+              Glyph={Glyph}
+              isSelected={tableSetup === value}
+              onClick={() => setTableSetup(value)}
             />
           ))}
         </div>
         { venueError && <p className="text-red-500 text-sm mt-1">{venueError}</p> }
-        <div className="flex items-center space-x-2 mt-4">
-          <Select onValueChange={(value) => setTableSetup(value)} defaultValue="Boardroom" >
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Boardroom Setup" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="Boardroom">Boardroom</SelectItem>
-              <SelectItem value="U-Shape">U-Shape</SelectItem>
-              <SelectItem value="Classroom">Classroom</SelectItem>
-              <SelectItem value="Intimate">Intimate - no tables</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
       </div>
     </>
   );

--- a/src/components/booking-widget-step-1.test.jsx
+++ b/src/components/booking-widget-step-1.test.jsx
@@ -59,9 +59,9 @@ describe('Step1', () => {
     expect(mockProps.setDate).toHaveBeenCalled();
   });
 
-  it('handles venue selection', () => {
+  it('handles layout selection', () => {
     const { getByText } = render(<Step1 {...mockProps} />);
-    fireEvent.click(getByText('Venue 1'));
-    expect(mockProps.setVenue).toHaveBeenCalledWith(1);
+    fireEvent.click(getByText('Classroom'));
+    expect(mockProps.setTableSetup).toHaveBeenCalledWith('Classroom');
   });
 });

--- a/src/components/booking-widget-step-2.jsx
+++ b/src/components/booking-widget-step-2.jsx
@@ -46,7 +46,7 @@ const Step2 = ({
 
   return (
     <div className="flex flex-col space-y-4 md:space-y-6 mt-8">
-      <h2 className="text-2xl font-bold text-center">Choose facilities & catering</h2>
+      <h2 className="text-xl font-bold text-center">Choose your extras</h2>
       <p className="text-center text-muted-foreground">Make your event complete</p>
 
       <div>
@@ -68,7 +68,7 @@ const Step2 = ({
 
       <div>
         <h3 className="text-lg text-primary font-medium">Catering arrangements</h3>
-        <p className="text-muted-foreground mt-2">Specific delivery times are be added later from your customer portal. For more details check our <a className="font-normal underline text-muted-foreground" href="https://www.creativepoint.nl/catering-options/" target='_blank'>catering section</a>.</p>
+        <p className="text-muted-foreground mt-2">If you want to keep your energy high choose your preferred catering options.</p>
         <div className="grid grid-cols-[repeat(auto-fill,_minmax(220px,_1fr))] gap-4 mt-4">
           {catering.map(cater => {
             const selectedCater = cateringSelected.find(item => item.id === cater.id);

--- a/src/components/booking-widget-step-2.test.jsx
+++ b/src/components/booking-widget-step-2.test.jsx
@@ -41,9 +41,9 @@ describe('Step2 Component', () => {
 
   test('renders Step2 component with facilities and catering sections', () => {
     renderComponent();
-    expect(screen.getByText(/Choose facilities & catering/i)).toBeInTheDocument();
+    expect(screen.getByText(/Choose your extras/i)).toBeInTheDocument();
     const facilityHeaders = screen.getAllByText(/Facilities/i);
-    expect(facilityHeaders).toHaveLength(2);
+    expect(facilityHeaders).toHaveLength(1);
     expect(screen.getByText(/Catering arrangements/i)).toBeInTheDocument();
   });
 

--- a/src/components/booking-widget-step-3.jsx
+++ b/src/components/booking-widget-step-3.jsx
@@ -23,6 +23,7 @@ const Step3 = ({
   phoneError: propPhoneError,
   agreeTermsError,
   isStep3Valid,
+  checkStep3Errors,
   handleSubmit,
   submitting
 }) => {
@@ -45,7 +46,6 @@ const Step3 = ({
   const checkStep3Validation = () => {
     let isValid = true;
 
-    console.log('Validating email:', email);
     if (!validateEmail(email)) {
       setEmailError('Invalid email address');
       isValid = false;
@@ -53,7 +53,6 @@ const Step3 = ({
       setEmailError('');
     }
 
-    console.log('Validating phone:', phone);
     if (!validatePhone(phone)) {
       setPhoneError('Invalid phone number');
       isValid = false;
@@ -66,7 +65,7 @@ const Step3 = ({
 
   return (
     <div className="flex flex-col space-y-4 md:space-y-6 mt-0 md:mt-8 max-w-[480px] mx-auto">
-      <h2 className="text-2xl font-bold text-center">Almost there!</h2>
+      <h2 className="text-xl font-bold text-center">Tell us who you are</h2>
       <p className="text-center text-muted-foreground">A couple extra details and your proposal is on it's way.</p>
 
       <div className="mt-4">
@@ -140,7 +139,7 @@ const Step3 = ({
       </div>
 
       <p className='text-muted-foreground text-sm'>
-        This is a non-binding request. We commit to reply within less than 10 minutes. Your data is not used for marketing or promotional reasons.
+        This is a non-binding request. Your data is not used for marketing or promotional reasons.
       </p>
       <div className="mt-4 text-center">
         <Button 
@@ -148,15 +147,12 @@ const Step3 = ({
           disabled={!isStep3Valid()} 
           onClick={(e) => {
             e.preventDefault();
-            console.log('Button clicked');
-            console.log('checkStep3Validation:', checkStep3Validation());
-            console.log('isStep3Valid:', isStep3Valid());
+            checkStep3Errors?.();
             if (checkStep3Validation() && isStep3Valid()) {
-              console.log('Calling handleSubmit');
               handleSubmit();
             }
           }}
-          aria-label="Request Proposal" // Added aria-label
+          aria-label="Request Quote" // Added aria-label
         >
           {submitting ? (
             <svg
@@ -172,7 +168,7 @@ const Step3 = ({
             </svg>
           )
           : (
-            <span>Request Proposal</span>
+            <span>Request Quote</span>
           )}
         </Button>
       </div>

--- a/src/components/booking-widget-step-3.test.jsx
+++ b/src/components/booking-widget-step-3.test.jsx
@@ -46,7 +46,7 @@ describe('Step3 Component', () => {
 
   test('renders the Step3 component with default props', () => {
     renderComponent();
-    expect(screen.getByText(/Almost there!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tell us who you are/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Company name/i)).toBeInTheDocument();
   });
 
@@ -87,14 +87,14 @@ describe('Step3 Component', () => {
 
   test('calls handleSubmit when the button is clicked and validations pass', () => {
     renderComponent();
-    const button = screen.getByRole('button', { name: /Request Proposal/i });
+    const button = screen.getByRole('button', { name: /Request Quote/i });
     fireEvent.click(button);
     expect(mockHandleSubmit).toHaveBeenCalled();
   });
 
   test('disables the button when isStep3Valid returns false', () => {
     renderComponent({ isStep3Valid: () => false });
-    const button = screen.getByRole('button', { name: /Request Proposal/i });
+    const button = screen.getByRole('button', { name: /Request Quote/i });
     expect(button).toBeDisabled();
   });
 

--- a/src/components/booking-widget.jsx
+++ b/src/components/booking-widget.jsx
@@ -693,13 +693,11 @@ export function BookingWidget(props) {
               handleSubmit={handleSubmit}
               submitting={submitting}
             />
-            <div className="hidden md:flex mt-12 flex justify-between items-center">
+            <div className="hidden md:flex mt-12 flex items-center space-x-4">
+              <Button variant="outline" onClick={() => setCurrentStep(2)}>
+                <ArrowLeftIcon className="h-5 w-5 text-muted-foreground" />
+              </Button>
               <span className="text-muted-foreground">Step 3 of 3</span>
-              <div className='flex space-x-4 items-center'>
-                <Button variant="outline" onClick={() => setCurrentStep(2)}>
-                  <ArrowLeftIcon className="mr-2 h-5 w-5 text-muted-foreground" />
-                </Button>
-              </div>
             </div>
           </>
         )}

--- a/src/components/booking-widget.jsx
+++ b/src/components/booking-widget.jsx
@@ -7,7 +7,8 @@ import Step1 from '@/components/booking-widget-step-1';
 import Step2 from '@/components/booking-widget-step-2';
 import Step3 from '@/components/booking-widget-step-3';
 import ThankYou from '@/components/thank-you';
-import { mockVenues, mockEventPackages, mockVenuePackages, facilities, catering } from '@/data';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { mockVenues, mockEventPackages, mockVenuePackages, facilities, catering, EXTRA_HOUR_RATE, extraHourZohoId } from '@/data';
 
 // Initialize Supabase client
 // const supabaseUrl = 'https://your-supabase-url.supabase.co';
@@ -37,6 +38,7 @@ export function BookingWidget(props) {
   const [eventPackages, setEventPackages] = useState([]);
   // const [event_package_price, setEventPackagePrice] = useState(0);
   const [selectedEventPackages, setSelectedEventPackages] = useState([]);
+  const [extraHours, setExtraHours] = useState(0);
   const [totalExclVat, setTotalExclVat] = useState(0);
   const [currentStep, setCurrentStep] = useState(1);
   // const [multiDayPackages, setMultiDayPackages] = useState([{}]); // state for multiple days packages
@@ -78,6 +80,9 @@ export function BookingWidget(props) {
           total += venuePackage.price;
         }
 
+        // Extra hours are priced per day (€EXTRA_HOUR_RATE each).
+        total += extraHours * EXTRA_HOUR_RATE;
+
         const selectedFacilities = facilitiesSelected.map(facilityId => facilities.find(facility => facility.id === facilityId));
         selectedFacilities.forEach(facility => {
           total += facility.price;
@@ -94,7 +99,7 @@ export function BookingWidget(props) {
     setTotalExclVat(total.toFixed(2));
 
     
-  }, [venue, selectedEventPackages, isMultiDay, endDate, facilitiesSelected, cateringSelected]);
+  }, [venue, selectedEventPackages, extraHours, isMultiDay, endDate, facilitiesSelected, cateringSelected]);
 
   useEffect(() => {
     scrollToTop();
@@ -262,21 +267,24 @@ export function BookingWidget(props) {
       startDateTime.setMinutes(startTime[1]);
       let endDateTime = null;
       const duration = selectedEventPackages.map(pkg => mockEventPackages.find(ep => ep.id === pkg).duration_hours).join(', ');
+      // Departure is driven by the last selected day's package hours plus any extra hours.
+      const lastPackageId = selectedEventPackages[selectedEventPackages.length - 1];
+      const lastDayHours = (mockEventPackages.find(ep => ep.id === lastPackageId)?.duration_hours ?? parseInt(duration)) + extraHours;
       if (isMultiDay && endDate) {
         endDateTime = new Date(endDate);
-      
+
         if (endTime && typeof endTime === 'string') {
         const endTimeParts = endTime.split(':');
         endDateTime.setHours(parseInt(endTimeParts[0]));
         endDateTime.setMinutes(parseInt(endTimeParts[1]));
         } else {
-          // use duration
-          endDateTime.setHours(parseInt(startTime[0]) + parseInt(duration));
+          // use duration (+ extra hours)
+          endDateTime.setHours(parseInt(startTime[0]) + lastDayHours);
           endDateTime.setMinutes(parseInt(startTime[1]));
         }
       } else {
         endDateTime = new Date(startDateTime);
-        endDateTime.setHours(startDateTime.getHours() + parseInt(duration));
+        endDateTime.setHours(startDateTime.getHours() + lastDayHours);
       }
 
       const totalValue = totalExclVat;
@@ -292,13 +300,14 @@ export function BookingWidget(props) {
         "Quote Date": quoteDate,
         "Event Start Date": new Date(startDateTime).toLocaleString("en-US", { timeZone: "Europe/Amsterdam" }),
         "Event End Date": new Date(endDateTime).toLocaleString("en-US", { timeZone: "Europe/Amsterdam" }),
-        "Duration": duration,
+        "Duration": extraHours > 0 ? `${duration} (+${extraHours}h extra)` : duration,
         "Total Value": totalValue,
         "Venue": venueName,
         "Items": facilitiesSelected.map(facilityId => facilities.find(facility => facility.id === facilityId).title[language]).join(', ') + ', ' + cateringSelected.map(cateringItem => catering.find(cater => cater.id === cateringItem.id).title[language]).join(', '),
         "Status": "Pending",
         "Comments": comments,
-        "adsID": adsID
+        "adsID": adsID,
+        "Layout": tableSetup
       };
       // console.log('Data to Google Sheets:', dataToGoogleSheets);
       const googleSheetsSuccess = await sendToGoogleSheets(dataToGoogleSheets); 
@@ -396,6 +405,7 @@ export function BookingWidget(props) {
       dataToGoogleSheets['Status'],
       dataToGoogleSheets['Comments'],
       dataToGoogleSheets['adsID'],
+      dataToGoogleSheets['Layout'],
     ];
 
     try {
@@ -526,15 +536,24 @@ export function BookingWidget(props) {
           });
         }
       });
-  
+
+      // Extra hours: €60/hr line item, multiplied by the number of days for multi-day bookings.
+      if (extraHours > 0) {
+        const days = isMultiDay ? Math.ceil((new Date(endDate) - new Date(date)) / (1000 * 60 * 60 * 24)) : 1;
+        line_items.push({
+          item_id: extraHourZohoId,
+          quantity: extraHours * days,
+        });
+      }
+
       // Step 3: Construct and send the estimate data
       const estimateData = {
         customer_id: customer_id,
         line_items: line_items,
         date: new Date().toISOString().split('T')[0],
-        notes: comments,
-        // custom subject i.e: Half Day for 17/01/2025 at Blossom
-        custom_subject: `${selectedEventPackages.map(pkg => mockEventPackages.find(ep => ep.id === pkg).short_description[language]).join(', ')} for ${new Date(date).toLocaleDateString('en-CA')} at ${venues.find(v => v.id === venue)?.name[language]}`,
+        notes: `Layout: ${tableSetup}${comments ? `\n${comments}` : ''}`,
+        // custom subject i.e: Half Day (+2h extra) for 17/01/2025 at Blossom
+        custom_subject: `${selectedEventPackages.map(pkg => mockEventPackages.find(ep => ep.id === pkg).short_description[language]).join(', ')}${extraHours > 0 ? ` (+${extraHours}h extra)` : ''} for ${new Date(date).toLocaleDateString('en-CA')} at ${venues.find(v => v.id === venue)?.name[language]}`,
       };
   
       try {
@@ -580,11 +599,10 @@ export function BookingWidget(props) {
     )
   : (
     <div className="grid grid-rows-[1fr_fit]  overflow-hidden lg:flex lg:flex-row justify-center lg:space-x-8 lg:overflow-visible" ref={widgetRef}>
-      <div id="booking-widget" className="w-full p-4 mt-8 overflow-scroll" ref={widgetRef}>  
+      <div id="booking-widget" className="w-full p-4 mt-8 overflow-scroll" ref={widgetRef}>
+        <StepIndicator currentStep={currentStep} />
         {currentStep === 1 && (
           <>
-            <h2 className="text-2xl font-bold text-center">Let's get you started</h2>
-            <p className="text-center text-muted-foreground mt-6">{`Grab your free quote. It only takes a minute!`}</p>
             <Step1
               language={language}
               guests={guests}
@@ -613,6 +631,8 @@ export function BookingWidget(props) {
               eventPackagesError={eventPackagesError}
               selectedEventPackages={selectedEventPackages}
               setSelectedEventPackages={setSelectedEventPackages}
+              extraHours={extraHours}
+              setExtraHours={setExtraHours}
               venues={venues}
             />
             <div className="mt-12 space-y-8 flex flex-col items-center">
@@ -679,26 +699,6 @@ export function BookingWidget(props) {
                 <Button variant="outline" onClick={() => setCurrentStep(2)}>
                   <ArrowLeftIcon className="mr-2 h-5 w-5 text-muted-foreground" />
                 </Button>
-                <Button 
-                  aria-label="Request Proposal BW"
-                  disabled={!isStep3Valid()}
-                  onClick={() => {
-                    if (checkStep3Errors() && isStep3Valid()) {
-                      handleSubmit()
-                    }
-                  }}>
-                  {submitting ? 
-                    (
-                      <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                      </svg>
-                    )
-                  : (
-                    <span className="flex space-x-2">Request Proposal <ArrowRightIcon className="ml-2 h-5 w-5 text-white" />
-                    </span>
-                  )}
-                </Button>
               </div>
             </div>
           </>
@@ -726,6 +726,7 @@ export function BookingWidget(props) {
         }))}
         facilitiesSelected={facilities.filter(facility => facilitiesSelected.includes(facility.id))}
         cateringSelected={cateringSelected.map(item => ({ ...item, name: catering.find(cater => cater.id === item.id).title[language], price: catering.find(cater => cater.id === item.id).price}))}
+        extraHours={extraHours}
         totalExclVat={totalExclVat}
         handleSubmit={handleSubmit}
         submitting={submitting}

--- a/src/components/booking-widget.test.jsx
+++ b/src/components/booking-widget.test.jsx
@@ -27,7 +27,7 @@ describe('BookingWidget Component', () => {
 
   test('renders BookingWidget component with initial step', () => {
     renderComponent();
-    expect(screen.getByText(/Let's get you started/i)).toBeInTheDocument();
+    expect(screen.getByText(/Get a tailored quote in 3 steps/i)).toBeInTheDocument();
   });
 
   test('navigates to Step 2 when Step 1 is completed', () => {
@@ -35,12 +35,11 @@ describe('BookingWidget Component', () => {
 
     // Fill in Step 1 inputs
     fireEvent.change(screen.getByLabelText(/Number of guests/i), { target: { value: '12' } });
-    fireEvent.click(screen.getByLabelText(/8 Hours/i));
-    fireEvent.click(screen.getByLabelText(/Blossom/i));
+    fireEvent.click(screen.getByLabelText(/Full day/i));
     fireEvent.click(screen.getByLabelText('Add Event Options'));
 
     // Validate transition to Step 2
-    expect(screen.getByText(/Choose facilities & catering/i)).toBeInTheDocument();
+    expect(screen.getByText(/Choose your extras/i)).toBeInTheDocument();
   });
 
   test('navigates to Step 3 when Step 2 is completed', () => {
@@ -48,16 +47,15 @@ describe('BookingWidget Component', () => {
 
     // Complete Step 1
     fireEvent.change(screen.getByLabelText(/Number of guests/i), { target: { value: '12' } });
-    fireEvent.click(screen.getByLabelText(/8 Hours/i));
-    fireEvent.click(screen.getByLabelText(/Blossom/i));
+    fireEvent.click(screen.getByLabelText(/Full day/i));
     fireEvent.click(screen.getByLabelText('Add Event Options'));
 
     // Complete Step 2
-    fireEvent.click(screen.getByText(/Choose facilities & catering/i));
+    fireEvent.click(screen.getByText(/Choose your extras/i));
     fireEvent.click(screen.getByLabelText('Next'));
 
     // Validate transition to Step 3
-    expect(screen.getByText(/Almost there!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tell us who you are/i)).toBeInTheDocument();
   });
 
   test('calls handleSubmit on final step submission', async () => {
@@ -66,12 +64,11 @@ describe('BookingWidget Component', () => {
 
     // Complete Step 1
     fireEvent.change(screen.getByLabelText(/Number of guests/i), { target: { value: '12' } });
-    fireEvent.click(screen.getByLabelText(/8 Hours/i));
-    fireEvent.click(screen.getByLabelText(/Blossom/i));
+    fireEvent.click(screen.getByLabelText(/Full day/i));
     fireEvent.click(screen.getByLabelText('Add Event Options'));
 
     // Complete Step 2
-    fireEvent.click(screen.getByText(/Choose facilities & catering/i));
+    fireEvent.click(screen.getByText(/Choose your extras/i));
     fireEvent.click(screen.getByLabelText('Next'));
 
     // Simulate final submission
@@ -80,7 +77,7 @@ describe('BookingWidget Component', () => {
     fireEvent.change(screen.getByPlaceholderText(/Last name/i), { target: { value: 'Doe' } });
     fireEvent.change(screen.getByPlaceholderText(/Email/i), { target: { value: 'john.doe@example.com' } });
     fireEvent.change(screen.getByPlaceholderText(/Phone/i), { target: { value: '+1234567890' }});
-    const button = screen.getByLabelText('Request Proposal BW');
+    const button = screen.getByLabelText('Request Quote');
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -96,10 +93,9 @@ describe('BookingWidget Component', () => {
     fireEvent.change(screen.getByLabelText(/Number of guests/i), { target: { value: '15' } });
   
     // Step 1: Select a duration
-    fireEvent.click(screen.getByLabelText(/8 Hours/i));
+    fireEvent.click(screen.getByLabelText(/Full day/i));
   
     // Step 1: Select a venue
-    fireEvent.click(screen.getByLabelText(/Blossom/i));
   
     // Step 1: Toggle the multi-day switch
     fireEvent.click(screen.getByLabelText(/Multi day event/i));
@@ -116,7 +112,7 @@ describe('BookingWidget Component', () => {
     fireEvent.click(screen.getByLabelText('Add Event Options'));
   
     // Validate that Step 2 is loaded
-    expect(screen.getByText(/Choose facilities & catering/i)).toBeInTheDocument();
+    expect(screen.getByText(/Choose your extras/i)).toBeInTheDocument();
   
     // Step 2: Select a facility
     fireEvent.click(screen.getByText(/Conference System/i));
@@ -136,7 +132,7 @@ describe('BookingWidget Component', () => {
     fireEvent.change(screen.getByPlaceholderText(/Phone/i), { target: { value: '+1234567890' } });
   
     // Submit the form
-    fireEvent.click(screen.getByLabelText('Request Proposal BW'));
+    fireEvent.click(screen.getByLabelText('Request Quote'));
   
     // Wait for final step to be reached
     await waitFor(() => {
@@ -166,14 +162,13 @@ const validateTotalCalculation = async (guestCount, durationLabel, venueLabel, f
   // Step 1: Select a duration
   fireEvent.click(screen.getByLabelText(new RegExp(`${durationLabel}`, 'i')));
 
-  // Step 1: Select a venue
-  fireEvent.click(screen.getByLabelText(new RegExp(`${venueLabel}`, 'i')));
+  // Venue is fixed (single venue, auto-selected) — venueLabel kept for readability
 
   // Proceed to the next step
   fireEvent.click(screen.getByLabelText('Add Event Options'));
 
   // Validate that Step 2 is loaded
-  expect(screen.getByText(/Choose facilities & catering/i)).toBeInTheDocument();
+  expect(screen.getByText(/Choose your extras/i)).toBeInTheDocument();
 
   // Step 2: Select facilities
   facilityLabels.forEach(facility => {
@@ -205,31 +200,30 @@ const validateTotalCalculation = async (guestCount, durationLabel, venueLabel, f
 
 // Different combinations for total calculation validation
 test('calculates total correctly for combination 1', async () => {
-  await validateTotalCalculation(10, '4 Hours', 'Blossom', ['Flip-charts'], ['Fruits & Snacks'], '570.00');
+  await validateTotalCalculation(10, 'Half day', 'Blossom', ['Flip-charts'], ['Fruits & Snacks'], '570.00');
 });
 
 test('calculates total correctly for combination 2', async () => {
-  await validateTotalCalculation(20, '8 Hours', 'Blossom', ['Remote Attendees'], ['Lunch', 'Beverages'], '1330.00');
+  await validateTotalCalculation(20, 'Full day', 'Blossom', ['Remote Attendees'], ['Lunch', 'Beverages'], '1330.00');
 });
 
 test('calculates total correctly for combination 3', async () => {
-  await validateTotalCalculation(15, '8 Hours', 'Blossom', ['Flip-charts', 'Remote Attendees'], ['Breakfast', 'Fruits & Snacks'], '1155.00');
+  await validateTotalCalculation(15, 'Full day', 'Blossom', ['Flip-charts', 'Remote Attendees'], ['Breakfast', 'Fruits & Snacks'], '1155.00');
 });
 
 test('calculates total correctly for combination 4', async () => {
-  await validateTotalCalculation(8, '4 Hours', 'Blossom', [], ['Lunch'], '592.00');
+  await validateTotalCalculation(8, 'Half day', 'Blossom', [], ['Lunch'], '592.00');
 });
 
 test('calculates total correctly when event package is selected after venue (regression: zero total bug)', async () => {
   render(<BookingWidget />);
 
   fireEvent.change(screen.getByLabelText(/Number of guests/i), { target: { value: '10' } });
-  fireEvent.click(screen.getByLabelText(/Blossom/i));
-  // Select package AFTER venue — this is the sequence that triggered the zero total bug
-  fireEvent.click(screen.getByLabelText(/4 Hours/i));
+  // Venue is auto-selected; selecting a package should compute a non-zero total (regression)
+  fireEvent.click(screen.getByLabelText(/Half day/i));
   fireEvent.click(screen.getByLabelText('Add Event Options'));
 
-  expect(screen.getByText(/Choose facilities & catering/i)).toBeInTheDocument();
+  expect(screen.getByText(/Choose your extras/i)).toBeInTheDocument();
 
   await waitFor(() => expect(screen.getByText(/Overview/i)).toBeInTheDocument());
   const overviewButton = screen.queryByText(/Overview/i);

--- a/src/components/icons.jsx
+++ b/src/components/icons.jsx
@@ -242,3 +242,90 @@ export function ArrowUpCircleIcon(props) {
     </svg>)
   );
 }
+
+// ── Seating-layout glyphs (0 0 24 24, currentColor) ─────────────────────────
+
+export function BoardroomGlyph(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg">
+      <rect x="6" y="9" width="12" height="6" rx="1" />
+      <circle cx="8" cy="6.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="6.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="6.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="8" cy="17.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="17.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="17.5" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function UShapeGlyph(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 5 V14 a2 2 0 0 0 2 2 H14 a2 2 0 0 0 2 -2 V5" />
+      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+      <circle cx="5" cy="11" r="1" fill="currentColor" stroke="none" />
+      <circle cx="19" cy="7" r="1" fill="currentColor" stroke="none" />
+      <circle cx="19" cy="11" r="1" fill="currentColor" stroke="none" />
+      <circle cx="10" cy="19" r="1" fill="currentColor" stroke="none" />
+      <circle cx="14" cy="19" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function ClassroomGlyph(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg">
+      <line x1="9" y1="4" x2="15" y2="4" />
+      <line x1="6" y1="13" x2="18" y2="13" />
+      <line x1="6" y1="18.5" x2="18" y2="18.5" />
+      <circle cx="8" cy="10.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="10.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="10.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="8" cy="16" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="16" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="16" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function CircleGlyph(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg">
+      <circle cx="12" cy="12" r="4.5" />
+      <circle cx="12" cy="4.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="18.5" cy="8.25" r="1" fill="currentColor" stroke="none" />
+      <circle cx="18.5" cy="15.75" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="19.5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="5.5" cy="15.75" r="1" fill="currentColor" stroke="none" />
+      <circle cx="5.5" cy="8.25" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+export function TheatreGlyph(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg">
+      <line x1="6" y1="5" x2="18" y2="5" />
+      <circle cx="8" cy="10" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="10" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="10" r="1" fill="currentColor" stroke="none" />
+      <circle cx="8" cy="14" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="14" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="14" r="1" fill="currentColor" stroke="none" />
+      <circle cx="8" cy="18" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="18" r="1" fill="currentColor" stroke="none" />
+      <circle cx="16" cy="18" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/src/components/ui/card-option.jsx
+++ b/src/components/ui/card-option.jsx
@@ -1,36 +1,63 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { CheckIcon } from '@/components/icons';
+import QuantityStepper from '@/components/ui/quantity-stepper';
 import { cn } from '@/lib/utils';
 
-export function CardOption({ title, id, description, onClick, isSelected, noneSelected, isDisabled }) {
+export function CardOption({
+  title,
+  subtitle,
+  id,
+  description,
+  onClick,
+  isSelected,
+  noneSelected,
+  isDisabled,
+  extraHours = 0,
+  onExtraHoursChange = () => {},
+  maxExtraHours = 0,
+  extraHourRate = 0,
+}) {
 
   return (
-    <Card className={cn("relative hover:opacity-[1] bg-gray-50 cursor-pointer", 
+    <Card className={cn("relative hover:opacity-[1] bg-gray-50 cursor-pointer",
       isSelected ? "border-primary" : !noneSelected ? "opacity-[0.5]" : '',
       isDisabled ? "cursor-not-allowed opacity-[0.5] hover:opacity-[0.5]" : '')}
       onClick={onClick}
-      aria-label={title}> 
+      aria-label={title}>
       <CardContent className="p-6">
         <h4 className="text-lg font-bold">{title}</h4>
+        {subtitle && <p className="text-sm font-medium text-primary">{subtitle}</p>}
         <p className="text-sm">{description}</p>
-        
-        <Button className="mt-4 outline-none" disabled={isDisabled} onClick={onClick}>
-          <span className={isSelected ? 'hidden': ''}>Choose</span>            
-          <div className={
-            `${!isSelected ? 'hidden': ''} animate-fade-in flex items-center justify-center border-2 border-white h-6 w-6 rounded-full m-1`
-            }>
-            <CheckIcon className="h-4 w-4 text-white " />
-          </div>
-        </Button>
-      </CardContent>
-      {/* {isSelected && (
-          <div className="md:absolute ml-6 mb-6 md:ml-0 md:mb-0 md:bottom-2 md:left-2 max-w-10 flex items-center justify-center rounded bg-primary">
-            <div className="flex items-center justify-center border-2 border-white h-6 w-6 rounded-full m-1">
-              <CheckIcon className="h-4 w-4 text-white" />
+
+        {isSelected ? (
+          <div className="mt-4 flex flex-col gap-1" onClick={(e) => e.stopPropagation()}>
+            {maxExtraHours > 0 && (
+              <p className={cn("text-xs", extraHours > 0 ? "font-medium text-primary" : "text-muted-foreground")}>
+                {extraHours > 0
+                  ? `+${extraHours} hr${extraHours === 1 ? '' : 's'} · €${extraHours * extraHourRate}${extraHours >= maxExtraHours ? ' (max)' : ''}`
+                  : `Add extra hours · €${extraHourRate}/hr`}
+              </p>
+            )}
+            <div className="w-fit flex items-center rounded-full border-primary border-2 p-1 gap-2">
+              <div className="flex items-center justify-center bg-primary h-6 w-6 rounded-full">
+                <CheckIcon className="h-4 w-4 text-white" />
+              </div>
+              {maxExtraHours > 0 && (
+                <QuantityStepper
+                  value={extraHours}
+                  onChange={onExtraHoursChange}
+                  min={0}
+                  max={maxExtraHours}
+                  label="extra hours"
+                />
+              )}
             </div>
           </div>
-        )} */}
+        ) : (
+          <Button className="mt-4 outline-none" disabled={isDisabled} onClick={onClick}>Choose</Button>
+        )}
+      </CardContent>
     </Card>
   );
 }

--- a/src/components/ui/layout-card-option.jsx
+++ b/src/components/ui/layout-card-option.jsx
@@ -1,0 +1,27 @@
+import { Card } from "@/components/ui/card";
+import { CheckIcon } from "@/components/icons";
+import { cn } from "@/lib/utils";
+
+export function LayoutCardOption({ label, Glyph, isSelected, onClick }) {
+  return (
+    <Card
+      role="radio"
+      aria-checked={isSelected}
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        "relative flex flex-col items-center justify-center gap-2 p-3 bg-gray-50",
+        "border-2 border-transparent cursor-pointer transition-colors hover:border-primary",
+        isSelected && "border-primary bg-primary/5"
+      )}
+    >
+      {isSelected && (
+        <div className="absolute top-1.5 right-1.5 flex items-center justify-center h-5 w-5 rounded-full bg-primary animate-fade-in">
+          <CheckIcon className="h-3.5 w-3.5 text-white" />
+        </div>
+      )}
+      <Glyph className={cn("h-10 w-10", isSelected ? "text-primary" : "text-muted-foreground")} />
+      <span className={cn("text-sm font-medium", isSelected && "text-primary")}>{label}</span>
+    </Card>
+  );
+}

--- a/src/components/ui/quantity-stepper.jsx
+++ b/src/components/ui/quantity-stepper.jsx
@@ -3,12 +3,14 @@ import { Button } from '@/components/ui/button';
 import { MinusIcon, PlusIcon } from '@/components/icons';
 
 /**
- * A small −/value/+ stepper. The catering card's stepper is hard-coded
- * disabled; this is the reusable, enabled version used for extra hours.
+ * Borderless −/value/+ stepper, styled to match the catering card's control.
+ * The parent supplies the surrounding pill/border, so this renders inline:
+ * the value followed by the minus and plus buttons next to each other.
  */
 const QuantityStepper = ({ value, onChange, min = 0, max = Infinity, label }) => {
   return (
-    <div className="w-fit flex items-center justify-center rounded-full border-primary border-2 p-1 space-x-2">
+    <div className="flex items-center space-x-2">
+      <p className="text-primary font-medium min-w-5 text-center" aria-label={label}>{value}</p>
       <Button
         type="button"
         variant="outline"
@@ -19,7 +21,6 @@ const QuantityStepper = ({ value, onChange, min = 0, max = Infinity, label }) =>
       >
         <MinusIcon className="h-5 w-5 text-primary group-hover:text-white" />
       </Button>
-      <p className="text-primary font-medium min-w-5 text-center" aria-label={label}>{value}</p>
       <Button
         type="button"
         variant="outline"

--- a/src/components/ui/quantity-stepper.jsx
+++ b/src/components/ui/quantity-stepper.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { MinusIcon, PlusIcon } from '@/components/icons';
+
+/**
+ * A small −/value/+ stepper. The catering card's stepper is hard-coded
+ * disabled; this is the reusable, enabled version used for extra hours.
+ */
+const QuantityStepper = ({ value, onChange, min = 0, max = Infinity, label }) => {
+  return (
+    <div className="w-fit flex items-center justify-center rounded-full border-primary border-2 p-1 space-x-2">
+      <Button
+        type="button"
+        variant="outline"
+        aria-label={`Decrease ${label || 'quantity'}`}
+        className="!h-7 !w-7 p-1 group rounded-full flex items-center justify-center border-primary text-primary hover:bg-primary hover:text-white text-lg"
+        onClick={() => onChange(Math.max(min, value - 1))}
+        disabled={value <= min}
+      >
+        <MinusIcon className="h-5 w-5 text-primary group-hover:text-white" />
+      </Button>
+      <p className="text-primary font-medium min-w-5 text-center" aria-label={label}>{value}</p>
+      <Button
+        type="button"
+        variant="outline"
+        aria-label={`Increase ${label || 'quantity'}`}
+        className="!h-7 !w-7 p-1 group rounded-full flex items-center justify-center border-primary text-primary hover:bg-primary hover:text-white text-lg"
+        onClick={() => onChange(Math.min(max, value + 1))}
+        disabled={value >= max}
+      >
+        <PlusIcon className="h-5 w-5 text-primary group-hover:text-white" />
+      </Button>
+    </div>
+  );
+};
+
+export default QuantityStepper;

--- a/src/components/ui/step-indicator.jsx
+++ b/src/components/ui/step-indicator.jsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+import { CheckIcon } from "@/components/icons";
+
+const steps = [
+  { num: 1, label: "Basic details" },
+  { num: 2, label: "Extras" },
+  { num: 3, label: "About you" },
+];
+
+export function StepIndicator({ currentStep }) {
+  return (
+    <div className="flex flex-col items-center mt-8">
+      <h2 className="text-2xl font-bold text-center">Get a tailored quote in 3 steps</h2>
+      <div className="flex items-center justify-center mt-6 w-full max-w-[460px]">
+        {steps.map((step, index) => {
+          const isActive = currentStep === step.num;
+          const isComplete = currentStep > step.num;
+          return (
+            <div key={step.num} className="flex items-center flex-1 last:flex-none">
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    "flex items-center justify-center h-8 w-8 rounded-full text-sm font-medium border-2 transition-colors",
+                    isActive && "bg-primary text-white border-primary",
+                    isComplete && "bg-primary/10 text-primary border-primary",
+                    !isActive && !isComplete && "bg-gray-50 text-muted-foreground border-gray-200"
+                  )}
+                >
+                  {isComplete ? <CheckIcon className="h-4 w-4" /> : step.num}
+                </div>
+                <span
+                  className={cn(
+                    "mt-1 text-xs whitespace-nowrap",
+                    isActive ? "text-primary font-medium" : "text-muted-foreground"
+                  )}
+                >
+                  {step.label}
+                </span>
+              </div>
+              {index < steps.length - 1 && (
+                <div
+                  className={cn(
+                    "flex-1 h-0.5 mx-2 -mt-5",
+                    currentStep > step.num ? "bg-primary" : "bg-gray-200"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/venue-card-option.jsx
+++ b/src/components/ui/venue-card-option.jsx
@@ -10,7 +10,8 @@ export function VenueCardOption({
   image_url,
   capacity,
   area,
-  onClick
+  onClick,
+  displayOnly
 }) {
 
   return (
@@ -36,15 +37,17 @@ export function VenueCardOption({
           <RulerIcon className="h-5 w-5 text-muted-foreground" />
           <p className="text-sm">{`${area} m^2`}</p>
         </div>
-        
-        <Button className="mt-4 outline-none" onClick={onClick}>
-          <span className={isSelected ? 'hidden' : ''}>Choose</span>            
-          <div className={
-            `${!isSelected ? 'hidden' : ''} animate-fade-in flex items-center justify-center border-2 border-white h-6 w-6 rounded-full m-1`
-            }>
-            <CheckIcon className="h-4 w-4 text-white " />
-          </div>
-        </Button>
+
+        {!displayOnly && (
+          <Button className="mt-4 outline-none" onClick={onClick}>
+            <span className={isSelected ? 'hidden' : ''}>Choose</span>
+            <div className={
+              `${!isSelected ? 'hidden' : ''} animate-fade-in flex items-center justify-center border-2 border-white h-6 w-6 rounded-full m-1`
+              }>
+              <CheckIcon className="h-4 w-4 text-white " />
+            </div>
+          </Button>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -66,22 +66,31 @@ export const mockEventPackages = [
   },
   {
     id: "3",
-    zoho_id: "936322000000089908",
-    duration_hours: 1,
+    zoho_id: "936322000000090488",
+    duration_hours: 2,
     duration_minutes: 0,
     short_description: {
-      en: "Hourly Rate",
-      nl: "Uurtarief",
+      en: "Weekend / Evening",
+      nl: "Weekend / Avond",
     },
     description: {
-      en: "During weekends or evenings. Minimum booking for 2 hours.",
-      nl: "In het weekend of 's avonds. Minimale boeking voor 2 uur.",
+      en: "During weekends or evenings. Includes 2 hours.",
+      nl: "In het weekend of 's avonds. Inclusief 2 uur.",
     },
     is_multi_day: false,
     is_increment_rate: 1,
-    rate: 120.0,
+    rate: 270.0,
   },
 ];
+
+// Flat rate for each extra hour added on top of the selected duration.
+export const EXTRA_HOUR_RATE = 60;
+
+// Maximum total hours per day (selected duration + extra hours).
+export const MAX_TOTAL_HOURS = 12;
+
+// Zoho item id for the €60/hr extra-hours line item (org 20113447459).
+export const extraHourZohoId = "936322000000090454";
 
 export const mockVenuePackages = [
   {
@@ -100,7 +109,7 @@ export const mockVenuePackages = [
     id: "3",
     venue_id: "1",
     package_id: "3",
-    price: 120,
+    price: 270,
   },
   {
     id: "4",
@@ -118,7 +127,7 @@ export const mockVenuePackages = [
     id: "6",
     venue_id: "2",
     package_id: "3",
-    price: 120,
+    price: 270,
   },
 ];
 


### PR DESCRIPTION
## Summary
Implements the requested UX/copy changes for the public reservation form (see `docs/reservation-form-requested-changes.md` and the plan in `docs/plans/`).

### Form / UX
- **Header:** persistent step indicator — *"Get a tailored quote in 3 steps"* + `Basic details · Extras · About you`, with per-step headings (*Give us the basic details / Choose your extras / Tell us who you are*).
- **Durations:** Full day (8h) / Half day (4h) / **Weekend-Evening (2h @ €270)**; cards show label + duration/price.
- **Extra hours:** in-card −/+ stepper (**€60/hr**, capped so duration + extra ≤ **12h**) with live cost, replacing the old orphaned module.
- **Layout:** *"What layout do you require?"* — a grid of 5 selectable tiles with seating glyphs (Boardroom / U-shape / Classroom / Circle / Theatre); the venue image is demoted to a compact banner (single venue, display-only).
- **Copy/CTA:** new catering copy; final step → *"Tell us who you are"*; removed the 10-minute sentence and the duplicate submit button; CTA renamed **"Request Quote"** everywhere.

### Backend wiring
- **Layout** is sent to Google Sheets (new **trailing** column) and the Zoho estimate `notes`.
- **Event end time** and the Zoho `custom_subject` now account for extra hours.
- Correct **org-`20113447459`** Zoho item IDs: €270 package `936322000000090488`, €60/hr extra hour `936322000000090454`.

### New components
`step-indicator`, `quantity-stepper`, `layout-card-option`, and 5 seating-glyph icons.

## Testing
- `npm run build` passes.
- Tests **40/42** via `CI=true npx vitest run`. The 2 failures are **pre-existing** submit-flow timeouts (real `fetch` to unset `VITE_*` URLs) — identical on the base branch.
- ⚠️ `npm run lint` is broken in the repo (missing `eslint-plugin-import` plugin) — pre-existing, unrelated.

## Deploy / ops checklist
- [x] Google Sheet "Layout" column added (far right).
- [x] **Verify `ZOHO_ORGANIZATION_ID=20113447459`** is set on the Zoho wrapper's Vercel deployment (else estimates fail with "item not found"). The wrappers themselves need **no code changes**.
- [ ] If Layout should appear in confirmation **emails/calendar invites**, update the downstream management app's sheet-row reader (out of scope here).
- [ ] `dist/` is committed in this repo and must be rebuilt before deploy (not included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)